### PR TITLE
modify pages and widgets tag types

### DIFF
--- a/specs/manifest/index.html
+++ b/specs/manifest/index.html
@@ -138,7 +138,7 @@
 </td></tr>
 <tr>
 <td> pages </td>
-<td> Object </td>
+<td> Array </td>
 <td> 是 </td>
 <td> 路由信息
 </td></tr>
@@ -150,7 +150,7 @@
 </td></tr>
 <tr>
 <td> widgets </td>
-<td> Object </td>
+<td> Array </td>
 <td> 否 </td>
 <td> 卡片配置
 </td></tr></tbody><tfoot></tfoot></table>

--- a/specs/packaging/index.html
+++ b/specs/packaging/index.html
@@ -118,7 +118,7 @@
         </ul>
         
         <h2>common</h2>
-        <p>TBD @Huawei</p>
+        <p>common can include public resources such as component, res, and utils, which are used to store custom components, multimedia resources, and js files.</p>
         
     </section>
 


### PR DESCRIPTION
The pages and widgets tag may contain multiple members, so an array type is required instead of an object type.
@Shouqun @zhiqiangyu @QingAn @Sharonzd 