### PR TITLE
[packaging] Editorial fixes

### DIFF
--- a/specs/packaging/index.html
+++ b/specs/packaging/index.html
@@ -169,13 +169,13 @@
         <section>
             <h2>Integrity & Trustworthiness</h2>
             <p>
-                To ensure the integrity and trustworthiness, a MiniApp package should be protected by one or more digital signatures by the author (e.g. the MiniApp developer) and/or distributors (e.g. an application store) along with certificates issued by trusted authorities.
+                To ensure the integrity and trustworthiness, a MiniApp package SHOULD be protected by one or more digital signatures by the author (e.g. the MiniApp developer) and/or distributors (e.g. an application store) along with certificates issued by trusted authorities.
                 <li>A digital signature (with a valid certificate) by the author ensures the origin of the MiniApp, so that an end user or a hosting platform can decide whether to install the MiniApp package according to the knowledge about the author (e.g. credits, blacklist, quality).</li>
                 <li>A digital signature (with a valid certificate) by a distributor ensures the integrity of the package and trustworthiness of the delivery channel, so that the end user can be protected from tampered software and can benefit from a healthier ecosystem. </li>
             </p>
         
             <p>
-                Proven technologies such as [[RFC5652]](i.e. PKCS#7) can be used as the solution of the digital signatures for MiniApp package. Further evaluation is expected regarding whether it needs to be standardized in detail (e.g. the content scope under protection, additional attributes of concern, file format of the signature block, procedures), or is left to the discretion of implementations.
+                Proven technologies such as [[RFC5652]] (i.e. PKCS#7) can be used as the solution of the digital signatures for MiniApp package. Further evaluation is expected regarding whether it needs to be standardized in detail (e.g. the content scope under protection, additional attributes of concern, file format of the signature block, procedures), or is left to the discretion of implementations.
             </p>
         </section>
         


### PR DESCRIPTION
Use all-caps for an RFC 2119 keyword and add a space.