### PR TITLE
Remove the Out of Scope section of the WG charter

### DIFF
--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -132,14 +132,6 @@
     <li>Elements and APIs that would enhance the interoperability among different MiniApp platforms, including UI elements, Device API, and those advanced APIs such as Account API and Map API;
     <li>Coordination with other W3C efforts, especially Progressive Web Apps, on the commonality of Web features.
 </ol>
-        <div id="section-out-of-scope">
-          <h3 id="out-of-scope">
-            Out of Scope
-          </h3>
-          <p>
-            The group does not intend to discuss ideas related to MiniApp platform operation, developer tools, and other parts of the MiniApp ecosystem.
-          </p>
-        </div>
       </div>
       <div class="deliverables">
         <h2 id="deliverables">

--- a/charters/wg-2020.zh.html
+++ b/charters/wg-2020.zh.html
@@ -130,14 +130,6 @@
     <li>可以增强不同MiniApp平台之间的互操作性的元素和API，包括UI元素/组件，设备API以及Account API和Map API等高级API；
     <li>与渐进式Web应用（PWA）等其他W3C工作合作，在Web功能的通用性方面进行协调。
 </ol>
-        <div id="section-out-of-scope">
-          <h3 id="out-of-scope">
-            超出范围
-          </h3>
-          <p>
-            与MiniApp平台运营、开发者工具和MiniApp生态的其他部分有关的讨论不在工作组的工作范围之内。
-          </p>
-        </div>
       </div>
       <div class="deliverables">
         <h2 id="deliverables">


### PR DESCRIPTION
Fix #76.

Per https://www.w3.org/2020/06/11-miniapp-minutes.html#item06