### PR TITLE
Strengthen cooperation of lifecycle with W3C work

### DIFF
--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -186,7 +186,7 @@
           </dt>
           <dd>
             <p>
-              This specification defines the MiniApp lifecycle events and the process that enables developers to manage the lifecycle events of both MiniApp application lifecycle and each MiniApp page's lifecycle. MiniApp application lifecycle includes a set of events, including application initialization, application running in foreground, application running in background. MiniApp page lifecycle includes a set of events, including page loading, page first rendering ready, page running in foreground, page running in background and page unloading.
+              This specification defines the MiniApp lifecycle events and the process that enables developers to manage the lifecycle events of both MiniApp application lifecycle and each MiniApp page's lifecycle. MiniApp application lifecycle includes a set of events, including application initialization, application running in foreground, application running in background. MiniApp page lifecycle includes a set of events, including page loading, page first rendering ready, page running in foreground, page running in background and page unloading. Whenever possible, the specification should provide a mapping to existing Web specifications.
             </p>
             <p class="draft-status">
               <b>Draft state:</b> <a href="https://w3c.github.io/miniapp/specs/lifecycle/">In progress in MiniApp CG</a>
@@ -443,6 +443,13 @@
           </dt>
           <dd>
             The Web Performance Working Group develops the Page Visibility specification, whose features are related to those in the MiniApp Lifecycle specification.
+          </dd>
+          <dt>
+            <a href="https://www.w3.org/sw/">Service Workers Working Group
+</a>
+          </dt>
+          <dd>
+            The Service Workers Working Group develops the Service Workers specification, whose features are related to those in the MiniApp Lifecycle specification.
           </dd>
         </dl>
         <div>

--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -186,7 +186,7 @@
           </dt>
           <dd>
             <p>
-              This specification defines the MiniApp lifecycle events and the process that enables developers to manage the lifecycle events of both MiniApp application lifecycle and each MiniApp page's lifecycle. MiniApp application lifecycle includes a set of events, including application initialization, application running in foreground, application running in background. MiniApp page lifecycle includes a set of events, including page loading, page first rendering ready, page running in foreground, page running in background and page unloading. Whenever possible, the specification should provide a mapping to existing Web specifications.
+              This specification defines the MiniApp lifecycle events and the process that enables developers to manage the lifecycle events of both MiniApp application lifecycle and each MiniApp page's lifecycle. MiniApp application lifecycle includes a set of events, including application initialization, application running in foreground, application running in background. MiniApp page lifecycle includes a set of events, including page loading, page first rendering ready, page running in foreground, page running in background and page unloading. Whenever possible, the specification should provide a mapping to existing Web specifications such as <a href="https://www.w3.org/TR/service-workers/">Service Workers</a> and <a href="https://w3c.github.io/page-visibility/">Page Visibility</a>.
             </p>
             <p class="draft-status">
               <b>Draft state:</b> <a href="https://w3c.github.io/miniapp/specs/lifecycle/">In progress in MiniApp CG</a>

--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -445,8 +445,7 @@
             The Web Performance Working Group develops the Page Visibility specification, whose features are related to those in the MiniApp Lifecycle specification.
           </dd>
           <dt>
-            <a href="https://www.w3.org/sw/">Service Workers Working Group
-</a>
+            <a href="https://www.w3.org/sw/">Service Workers Working Group</a>
           </dt>
           <dd>
             The Service Workers Working Group develops the Service Workers specification, whose features are related to those in the MiniApp Lifecycle specification.


### PR DESCRIPTION
We did not find an event in MiniApp Lifecycle that cannot be polyfilled or added on the Web platform (if there is any, feedback is welcome). So if possible, it would be useful for the MiniApp Lifecycle specification to provide a mapping to existing Web specifications (kind of like the [interface definition language](https://heycam.github.io/webidl/#idl) and [ECMAScript binding](https://heycam.github.io/webidl/#ecmascript-binding) in Web IDL) so that the browsers can also implement them.