### PR TITLE
Explicit wording for WebApp Manifest extension in the charter

### DIFF
--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -162,7 +162,7 @@
           </dt>
           <dd>
             <p>
-              This specification defines a JSON-based manifest document that enables developers to set up descriptive information, window styling, page routing, feature policies, and other information of a MiniApp. The MiniApp Manifest specification will follow the recommendations to extend <a href="https://w3ctag.github.io/design-principles/#extend-manifests">existing manifest files</a>, provided by the <a href="https://w3ctag.github.io/design-principles/#extend-manifests">Web Platform Design Principles</a>, with the <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a> as reference. 
+              This specification defines a JSON-based manifest document that enables developers to set up descriptive information, window styling, page routing, feature policies, and other information of a MiniApp. The MiniApp Manifest specification will follow the recommendations of the <a href="https://w3ctag.github.io/design-principles/#extend-manifests">Web Platform Design Principles</a> to extend the <a href="https://www.w3.org/TR/appmanifest/">Web App Manifest</a>.
             </p>
             <p class="draft-status">
               <b>Draft state:</b> <a href="https://w3c.github.io/miniapp/specs/manifest/">In progress in MiniApp CG</a>


### PR DESCRIPTION
Explicit reference to the extension of the WebApp Manifest, according to #128 .   