### PR TITLE
Components and APIs in the charter scope, take 3

### DIFF
--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -450,6 +450,12 @@
           <dd>
             The Web Performance Working Group develops the Page Visibility specification, whose features are related to those in the MiniApp Lifecycle specification.
           </dd>
+          <dt>
+            <a href="https://www.w3.org/Style/CSS/">Cascading Style Sheets (CSS) Working Group</a>
+          </dt>
+          <dd>
+            The CSS Working Group develops mechanisms for adding style to components in Web applications, which is related to the potential UI component standardization in the group.
+          </dd>
         </dl>
         <div>
           <h3>

--- a/charters/wg-2020.html
+++ b/charters/wg-2020.html
@@ -141,7 +141,7 @@
 </p>
 <ol>
     <li>Basic architecture and essential functions of MiniApp such as the Manifest, Packaging, URI Solution, and Lifecycle; 
-    <li>Basic layout and components, APIs, and a template mechanism that would enhance the interoperability among different MiniApp platforms and the Web, including widget, UI components, etc.; 
+    <li>MiniApp UI components, component-associated APIs, and a page layout template mechanism that would enhance the interoperability among different MiniApp platforms and the Web. Other components and APIs may be included by rechartering the WG scope as the incubation result from the MiniApp Community Group.
     <li>Coordination with other W3C efforts, especially security, privacy, accessibility, internationalization and other Webapp APIs including Progressive Web Apps, on the commonality of the Web. 
 </ol>
       </div>


### PR DESCRIPTION
Fix #79 based on comment in https://github.com/w3c/miniapp/issues/79#issuecomment-656117621
