### PR TITLE
chore: fix ReSpec group config error

### DIFF
--- a/specs/manifest/index.html
+++ b/specs/manifest/index.html
@@ -53,7 +53,7 @@
                 companyURL: "http://www.huawei.com/",
                 company: "Huawei"
              }],
-            group: "miniapps",
+            group: "cg/miniapps",
             github: "w3c/miniapp",
             localBiblio:  {
              'SEMANTIC-VERSIONING': {


### PR DESCRIPTION
Before: https://w3c.github.io/miniapp/specs/manifest/?group=miniapps
After: https://w3c.github.io/miniapp/specs/manifest/?group=cg/miniapps