### PR TITLE
Updating charter and added two specs under development

### DIFF
--- a/charters/cg-2023.html
+++ b/charters/cg-2023.html
@@ -220,7 +220,7 @@ th { text-align: left }
               </tr>
               <tr>
                 <th>
-                  <a href="https://w3c.github.io/miniapp/charter.html">Initial Charter</a>
+                  <a href="https://w3c.github.io/miniapp/charters/cg.html">Initial Charter</a>
                 </th>
                 <td>
                   5 December 2019

--- a/charters/cg-2023.html
+++ b/charters/cg-2023.html
@@ -108,11 +108,13 @@ th { text-align: left }
     <p>Based on the <a href="https://www.w3.org/TR/mini-app-white-paper/">MiniApp Standardization White Paper</a> and previous discussion in the <a href="https://www.w3.org/2018/chinese-web-ig/">W3C Chinese Web Interest Group</a>, the following projects have been proposed as initial standardization exploration of MiniApp.</p>
 
     <ul>
-      <li>Application life cycle and events
-      <li>Manifest
-      <li>Packaging
-      <li>Addressing
-      <li>Widget
+      <li>Application life cycle and events (adopted by the <a href="https://www.w3.org/groups/wg/miniapps/">MiniApps Working Group</a> as <a href="https://www.w3.org/TR/miniapp-lifecycle/">MiniApp Lifecycle</a>)</li>
+      <li>Manifest (adopted by the <a href="https://www.w3.org/groups/wg/miniapps/">MiniApps Working Group</a> as <a href="https://www.w3.org/TR/miniapp-manifest/">MiniApp Manifest</a>)</li>
+      <li>Packaging (adopted by the <a href="https://www.w3.org/groups/wg/miniapps/">MiniApps Working Group</a> as <a href="https://www.w3.org/TR/miniapp-packaging/">MiniApp Packaging</a>)</li>
+      <li>Addressing (adopted by the <a href="https://www.w3.org/groups/wg/miniapps/">MiniApps Working Group</a> as <a href="https://www.w3.org/TR/miniapp-addressing/">MiniApp Addressing</a>)</li>
+      <li>Widget (<a href="https://github.com/w3c/miniapp-widget/blob/main/docs/explainer.md">MiniApp Widget Requirements</a>)</li>
+      <li><a href="https://w3c.github.io/miniapp-components/">MiniApp Components</a></li>
+      <li><a href="https://w3c.github.io/miniapp-iot/">MiniApp for IoT</a></li>
     </ul>
 
     <p>

--- a/charters/cg-2023.html
+++ b/charters/cg-2023.html
@@ -62,7 +62,7 @@ th { text-align: left }
         This Charter:
       </dt>
       <dd>
-        <a href="https://w3c.github.io/miniapp/charter.html">https://w3c.github.io/miniapp/charter.html</a>
+        <a href="https://w3c.github.io/miniapp/charters/cg-2023.html">https://w3c.github.io/miniapp/charters/cg-2023.html</a>
       </dd>
       <dt>
         Start Date:

--- a/charters/cg-2023.html
+++ b/charters/cg-2023.html
@@ -206,30 +206,44 @@ th { text-align: left }
         The following table lists details of all changes from the initial Charter.
     </p>
     <table class="history">
-            <tbody>
-              <tr>
-                <th>
-                  Charter Period
-                </th>
-                <th>
-                  Start Date
-                </th>
-                <th>
-                  Changes
-                </th>
-              </tr>
-              <tr>
-                <th>
-                  <a href="https://w3c.github.io/miniapp/charters/cg.html">Initial Charter</a>
-                </th>
-                <td>
-                  5 December 2019
-                </td>
-                <td>
-                  N/A
-                </td>
-              </tr>
-              </tbody>
-          </table>
+      <tbody>
+        <tr>
+          <th>
+            Charter Period
+          </th>
+          <th>
+            Start Date
+          </th>
+          <th>
+            Changes
+          </th>
+        </tr>
+        <tr>
+          <th>
+            <a href="https://w3c.github.io/miniapp/charters/cg.html">Initial Charter</a>
+          </th>
+          <td>
+            5 December 2019
+          </td>
+          <td>
+            N/A
+          </td>
+        </tr>
+        <tr>
+          <th>
+            <a href="https://w3c.github.io/miniapp/charters/cg.html">Charter Update</a>
+          </th>
+          <td>
+            6 November 2023
+          </td>
+          <td>
+            <ul>
+              <li>Added two new specifications: MiniApps for IoT and MiniApp Components.</li>
+              <li>Minor editorial changes.</li>
+            </ul>
+          </td>
+        </tr>
+        </tbody>
+    </table>
   </body>
 </html>

--- a/charters/cg-2023.html
+++ b/charters/cg-2023.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>
+      MiniApps Ecosystem Community Group
+    </title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/base">
+    <style>
+    body {
+      max-width: 60em;
+      margin: auto;
+    }
+    *:target {
+      background-color: yellow;
+    }
+    li {
+      margin-bottom:9pt;
+    }
+    p.firstelement, table, address { margin-top: 0.7em; }
+
+/* From https://www.w3.org/2005/09/table.css */
+table
+{
+	border-collapse: collapse;
+	margin: 1em auto;
+}
+
+table caption
+{
+	margin-left: auto;
+	margin-right: auto;
+}
+
+table, tr, th, td { border: 1px solid black; }
+th, td { padding: 5px 1em; }
+
+th
+{
+	background: #005a9c;
+	color: #fff;
+}
+
+th a:link {
+  color: #fff;
+}
+
+th a:visited {
+  color: #aaa;
+}
+
+th { text-align: left }
+    </style>
+  </head>
+  <body>
+    <h1>
+      MiniApps Ecosystem Community Group Charter
+    </h1>
+    <dl>
+      <dt>
+        This Charter:
+      </dt>
+      <dd>
+        <a href="https://w3c.github.io/miniapp/charter.html">https://w3c.github.io/miniapp/charter.html</a>
+      </dd>
+      <dt>
+        Start Date:
+      </dt>
+      <dd>
+        5 December 2019
+      </dd>
+      <dt>
+        Last Modified:
+      </dt>
+      <dd>
+        6 November 2023
+      </dd>
+    </dl>
+    <p>
+        The MiniApps Ecosystem Community Group provides a forum for the global community to discuss, incubate, and propose MiniApp-related standard ideas to bring more interoperability and robustness to the MiniApp ecosystem.
+    </p>
+    <h2 id="background">
+      Background
+    </h2>
+    <p>MiniApp as a new form of mobile application, leveraging both Web technologies (especially CSS and JavaScript) as well as capabilities of native applications, is gaining more and more popularity in Asian countries such as China. To enhance the interoperability between different MiniApp platforms (AKA the super application or host application), mainstream MiniApp vendors have been working together in <a href="https://www.w3.org/2018/chinese-web-ig/">W3C Chinese Web Interest Group</a> since May 2019 and published a <a href="https://www.w3.org/TR/mini-app-white-paper/">MiniApp Standardization White Paper</a> in September 2019 as the initial standardization exploration for MiniApp technologies.</p>
+
+    <p>As more global companies get interested in joining the MiniApp-related discussion, the MiniApp Ecosystem Community Group was proposed and approved during TPAC 2019 so the global Web community can join the discussion.</p>
+    <h2 id="scope">
+      Scope of Work
+    </h2>
+    <p>The MiniApp Ecosystem Community Group aims to discuss proposals for MiniApp features that would benefit the interoperability and robustness of the MiniApp ecosystem, including:</p>
+<ol>
+    <li>The basic architecture and essential functions of MiniApp, such as addressing, widget, application lifecycle and event, as well as Manifest;
+    <li>Elements and APIs that would enhance the interoperability among different MiniApp platforms, including UI elements, Device API, and advanced APIs such as Account API and Map API;
+    <li>Coordination with current W3C efforts, especially PWA, on the commonality of Web features;
+    <li>Carry out horizontal review for accessibility, internationalization, privacy, and security for MiniApp specifications;
+</ol>
+    <h2 id="nonscope">
+      Out of Scope
+    </h2>
+    <p>
+        The group does not intend to discuss ideas related to the MiniApp platform operation.
+    </p>
+    <h2 id="proposals">
+      Current Proposals
+    </h2>
+    <p>Based on the <a href="https://www.w3.org/TR/mini-app-white-paper/">MiniApp Standardization White Paper</a> and previous discussion in the <a href="https://www.w3.org/2018/chinese-web-ig/">W3C Chinese Web Interest Group</a>, the following projects have been proposed as initial standardization exploration of MiniApp.</p>
+
+    <ul>
+      <li>Application life cycle and events
+      <li>Manifest
+      <li>Packaging
+      <li>Addressing
+      <li>Widget
+    </ul>
+
+    <p>
+      New projects or status changes are communicated to the group through the public mailing list. Chairs and editors should publish status updates to the public mailing list to allow group participants to monitor progress without having to watch every repo directly.
+    </p>
+
+    <h2 id="coordination">
+        Coordination
+    </h2>
+    <p>
+        It is anticipated that the group will collaborate with appropriate W3C Working Groups and WHATWG work streams in order to transition spec proposals to the Recommendation or Living Standard track. This group will probably get into collaboration with the following groups:
+    </p>
+    <ul>
+      <li>Web Applications Working Group</li>
+      <li>Web Performance Working Group</li>
+      <li>Service Workers Working Group</li>
+      <li>Cascading Style Sheets (CSS) Working Group</li>
+      <li>Devices and Sensors Working Group</li>
+      <li>Web Application Security Working Group</li>
+      <li>Immersive Web Working Group</li>
+      <li>Web Incubator Community Group (WICG)</li>
+      <li>Accessible Platform Architectures Working Group</li>
+      <li>Machine Learning Community Group</li>
+      <li>Internationalization Working Group</li>
+      <li>Privacy Interest Group (PING)</li>
+      <li>WHATWG </li>
+    </ul>
+    <h2 id="process">
+      Community and Business Group Process and Patent Policy
+    </h2>
+    <p>
+      The group operates under the <a href=
+      "https://www.w3.org/community/about/agreements/">Community and Business
+      Group Process</a>. Terms in this charter that conflict with those of
+      the Community and Business Group Process are void.
+    </p>
+    <p>
+      As with other Community Groups, W3C seeks organizational licensing
+      commitments under the <a href=
+      'http://www.w3.org/community/about/agreements/cla/'>W3C Community
+      Contributor License Agreement (CLA)</a> (Proposals in this Community
+      Group charter are applicable "Specification" in the CLA). When people
+      request to participate without representing their organization’s legal
+      interests, W3C will in general approve those requests for this group with
+      the following understanding: W3C will seek and expect an organizational
+      commitment under the CLA starting with the individual’s first request to
+      make a contribution to a group deliverable. The section on <a href=
+      "#participation-and-contribution">Contribution Mechanics</a> describes how W3C expects to
+      monitor these contribution requests.
+    </p>
+    <h2 id="communication">
+        Communication
+    </h2>
+    <p>
+        The group tends to have monthly teleconferences and conducts its work on the public mailing list <a href="https://lists.w3.org/Archives/Public/public-miniapps/">public-miniapps@w3.org</a> as well as its <a href="https://github.com/w3c/miniapp">GitHub repository</a> for technical discussions. Other communication tools are allowed if a considerable number of the group participants decide to embrace them.
+    </p>
+    <h2 id="participation-and-contribution">
+        Participation and Contribution
+    </h2>
+    <p>Membership of the group is open to everybody but all participants will have signed the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement</a>. Chairs and editors of feature proposals must ensure that no contributions are adopted from anyone who is not a member of the Community Group.</p>
+
+    <p>Specifications created for proposals in the Community Group must use the <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Software and Document License</a>.</p>
+
+    <p>All Github repositories attached to the Community Group must contain a copy of the <a href="https://github.com/w3c/licenses/blob/master/CG-CONTRIBUTING.md">CONTRIBUTING</a> and <a href="https://github.com/w3c/licenses/blob/master/CG-LICENSE.md">LICENSE</a> files.</p>
+
+    <p>Note: this CG will not use a <em>contrib</em> mailing list for contributions since all contributions will be tracked via Github mechanisms (e.g., pull requests).</p>
+    <h2 id="decision">
+        Decision Policy
+    </h2>
+    <p>This group will seek to make decisions when there is consensus. Consensus will be recorded through meeting minutes or its GitHub repo issue list with assistance from the Chairs.</p>
+
+    <p>Any technical specification that is planned to be proposed to a W3C Working Group should require:</p>
+
+    <ul>
+    <li>2 MiniApp vendors who have the intention to implement the proposed specification(s)
+    <li>Reasonable support from MiniApp developers
+    </ul>
+    <h2 id="about">About this Charter</h2>
+    <h3 id="charter-change">
+      Amendments to the Charter
+    </h3>
+    <p>
+        This Charter can be amended by the Chairs with consultation of the Community Group.
+    </p>
+    <h3 id="history">
+      Charter History
+    </h3>
+    <p>
+        The following table lists details of all changes from the initial Charter.
+    </p>
+    <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <a href="https://w3c.github.io/miniapp/charter.html">Initial Charter</a>
+                </th>
+                <td>
+                  5 December 2019
+                </td>
+                <td>
+                  N/A
+                </td>
+              </tr>
+              </tbody>
+          </table>
+  </body>
+</html>


### PR DESCRIPTION
Close #201.

Updated the charter with :
- minor editorial changes, 
- updated the status of the previous specifications moved to the WG
- added MiniApps for IoT and MiniApp Components. 

See [diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fminiapp%2Fcharters%2Fcg.html&doc2=https%3A%2F%2Fraw.githack.com%2Fespinr%2Fminiapp%2Fcomponents-charter%2Fcharters%2Fcg-2023.html). 