### PR TITLE
Updated link to new CG charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 * [CG Homepage](https://www.w3.org/community/miniapps/)
 * [CG Specs](https://github.com/w3c/miniapp/tree/main/specs#cg-documents)
-* [CG Charter](https://w3c.github.io/miniapp/charters/cg.html)
+* [CG Charter](https://w3c.github.io/miniapp/charters/cg-2023.html)
 * [CG Meeting Minutes](https://github.com/w3c/miniapp/blob/main/Meetings/CG.md)
 * [CG Calendar](https://www.w3.org/groups/cg/miniapps/calendar)
 


### PR DESCRIPTION
Link to the new CG Charter, that includes two new documents: Components and MiniApps for IoT. 